### PR TITLE
Fix lxml compilation errors in Ubuntu 14.04 LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ### Vagrant ###
 .vagrant/
 vagrant_ansible_inventory*
+*.sql.gz

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,4 +19,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 1024
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,14 +10,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # sentry.vm.box_url = "https://dl.dropboxusercontent.com/s/z85s74gv74m6flo/centos-6-4.box"
     # sentry.vm.box = "wheezy64"
     # sentry.vm.box_url = "https://dl.dropboxusercontent.com/s/j887m9989t2g8zj/wheezy64.box"
-    sentry.vm.box = "precise32"
-    sentry.vm.box_url = "http://files.vagrantup.com/precise32.box"
+    sentry.vm.box = "ubuntu/trusty64"
     sentry.vm.network :private_network, ip: "192.168.33.10"
 
-    sentry.vm.provision "ansible" do |ansible| 
+    sentry.vm.provision "ansible" do |ansible|
       ansible.playbook = "sentry.yml"
       ansible.verbose = 'vvv'
-    end 
+    end
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,5 +37,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.playbook = "sentry.yml"
       ansible.verbose = 'vvv'
     end
+
+  end
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 1024
   end
 end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+hostfile = hosts

--- a/hosts
+++ b/hosts
@@ -1,2 +1,2 @@
 [digitalocean]
-host1 ansible_ssh_host=1.2.3.4 # replace with your server IP
+host1 ansible_ssh_host=sentry.studio38.de

--- a/hosts
+++ b/hosts
@@ -1,0 +1,2 @@
+[digitalocean]
+host1 ansible_ssh_host=1.2.3.4 # replace with your server IP

--- a/ping.sh
+++ b/ping.sh
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+ansible -u root --private-key ~/.ssh/digitalocean_rsa all -m ping
+## Use the following if you're using your default ssh key to connect to D.O.
+# ansible -u root all -m ping

--- a/provision.sh
+++ b/provision.sh
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+ansible-playbook -u root --private-key ~/.ssh/digitalocean_rsa sentry.yml -vvv
+## Use the following if you're using your default ssh key to connect to D.O.
+# ansible-playbook -u root sentry.yml -vvv

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: update timezone
+  command: dpkg-reconfigure --frontend noninteractive tzdata

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -19,9 +19,9 @@
   when: ansible_os_family == "Debian"
 
 - name: add PPA for redis
-  apt_repository: 
+  apt_repository:
     # This will fail unless Ubuntu ...
-    repo: ppa:chris-lea/redis-server 
+    repo: ppa:chris-lea/redis-server
   when: ansible_os_family == "Debian"
 
 - name: install common packages debian/ubuntu
@@ -50,3 +50,12 @@
     - '@development'
   when: ansible_os_family == "RedHat"
 
+- name: Set timezone variables
+  copy: content='Europe/Berlin\n'
+        dest=/etc/timezone
+        owner=root
+        group=root
+        mode=0644
+        backup=yes
+  notify:
+    - update timezone

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -32,6 +32,7 @@
     - python-dev
     - libxslt1-dev
     - libxml2-dev
+    - zlib1g-dev
     - libz-dev
     - libffi-dev
     - libssl-dev

--- a/roles/sentry/tasks/main.yml
+++ b/roles/sentry/tasks/main.yml
@@ -22,6 +22,11 @@
       path: /var/sentry
 # END
 
+- name: install security extensions for compiling lxml
+  pip:
+    name: requests[security]
+    virtualenv: /var/sentry/ve
+
 - name: install sentry and create virtualenv if needed
   pip:
     name: sentry[postgres]

--- a/roles/sentry/templates/sentry_conf.py.j2
+++ b/roles/sentry/templates/sentry_conf.py.j2
@@ -8,7 +8,7 @@ CONF_ROOT = os.path.dirname(__file__)
 
 DATABASES = {
     'default': {
-        'ENGINE': 'sentry.db.postgresql',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': '{{ db_sentry.name }}',
         'USER': '{{ db_sentry.user }}',
         'PASSWORD': '{{ db_sentry.password }}',

--- a/roles/sentry/templates/sentry_conf.py.j2
+++ b/roles/sentry/templates/sentry_conf.py.j2
@@ -1,8 +1,10 @@
-import os.path
-
+# This file is just Python, with a touch of Django which means
+# you can inherit and tweak settings to your hearts content.
 from sentry.conf.server import *
 
-ROOT = os.path.dirname(__file__)
+import os.path
+
+CONF_ROOT = os.path.dirname(__file__)
 
 DATABASES = {
     'default': {
@@ -10,7 +12,7 @@ DATABASES = {
         'NAME': '{{ db_sentry.name }}',
         'USER': '{{ db_sentry.user }}',
         'PASSWORD': '{{ db_sentry.password }}',
-        'HOST': '',
+        'HOST': 'localhost',
         'PORT': '',
     }
 }
@@ -38,12 +40,17 @@ DEBUG = False
 # Sentry currently utilizes two separate mechanisms. While CACHES is not a
 # requirement, it will optimize several high throughput patterns.
 
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': ['127.0.0.1:11211'],
-    }
-}
+# If you wish to use memcached, install the dependencies and adjust the config
+# as shown:
+#
+#   pip install python-memcached
+#
+# CACHES = {
+#     'default': {
+#         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+#         'LOCATION': ['127.0.0.1:11211'],
+#     }
+# }
 
 # A primary cache is required for things such as processing events
 SENTRY_CACHE = 'sentry.cache.redis.RedisCache'
@@ -116,7 +123,6 @@ SENTRY_FILESTORE_OPTIONS = {
     'location': '/tmp/sentry-files',
 }
 
-
 ##############
 # Web Server #
 ##############
@@ -142,7 +148,7 @@ SENTRY_WEB_OPTIONS = {
 SENTRY_PUBLIC = False
 SENTRY_FEATURES['auth:register'] = False
 
-ALLOWED_HOSTS = ['{{ sentry.server }}']
+ALLOWED_HOSTS = ['*']
 
 SENTRY_LOGIN_URL = '{{ sentry.url }}/login/'
 
@@ -155,6 +161,8 @@ SENTRY_OPTIONS['mail.port'] = {{ sentry_mail.port }}
 SENTRY_OPTIONS['mail.username'] = '{{ sentry_mail.username }}'
 SENTRY_OPTIONS['mail.password'] = '{{ sentry_mail.password }}'
 SENTRY_OPTIONS['mail.use-tls'] = {{ sentry_mail.use_tls }}
+SENTRY_OPTIONS['mail.backend'] = 'django.core.mail.backends.smtp.EmailBackend'
+SENTRY_OPTIONS['mail.mailgun-api-key'] = ''
 
 SENTRY_OPTIONS["redis.clusters"] = {
     'default': {

--- a/sentry.yml
+++ b/sentry.yml
@@ -10,8 +10,8 @@
       email: redacted
       password: redacted
     sentry:
-      server: redacted
-      url: redacted
+      server: 1.2.3.4
+      url: http://1.2.3.4
       secret_key: 'redacted'
     sentry_mail:
       host: localhost

--- a/sentry.yml
+++ b/sentry.yml
@@ -10,8 +10,8 @@
       email: redacted
       password: redacted
     sentry:
-      server: 1.2.3.4
-      url: http://1.2.3.4
+      server: sentry.studio38.de
+      url: http://sentry.studio38.de
       secret_key: 'redacted'
     sentry_mail:
       host: localhost


### PR DESCRIPTION
Hello @jean, your fork fixes a lot of problems with the upstream repo, but I still couldn't get it to run successfully. Lxml failed to compile during the task [sentry | install sentry and create virtualenv if needed].

These stackoverflow comments helped me get lxml to compile with Ubuntu 14.04 LTS, both in vagrant and on digital ocean (I had to increase the droplet memory capacity to 1024 MB):
- 1024 MB of RAM is needed: http://stackoverflow.com/questions/6504810/how-to-install-lxml-on-ubuntu/25372234#25372234
- zlib1g-dev is needed: http://stackoverflow.com/questions/6504810/how-to-install-lxml-on-ubuntu/19289133#19289133
- pyopenssl, ndg-httpsclient and pyasn1 are needed: http://stackoverflow.com/questions/29134512/insecureplatformwarning-a-true-sslcontext-object-is-not-available-this-prevent/29202163#29202163
